### PR TITLE
Bringing UniGrid output in line

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,42 +1,115 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[AbstractGPs]]
+deps = ["ChainRulesCore", "Distributions", "FillArrays", "KernelFunctions", "LinearAlgebra", "Random", "RecipesBase", "Reexport", "Statistics", "StatsBase", "Test"]
+git-tree-sha1 = "d1b311e6f0358fa73c82473daf23de6ba1148900"
+uuid = "99985d1d-32ba-4be9-9821-2ec096f28918"
+version = "0.3.10"
+
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.1"
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
+[[Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.8+0"
+
+[[Cairo_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "f2202b55d816427cd385a9a4f3ffb226bee80f99"
+uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
+version = "1.16.1+0"
+
+[[ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "4c26b4e9e91ca528ea212927326ece5918a04b47"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.11.2"
+
+[[ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
+
 [[Clustering]]
 deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "SparseArrays", "Statistics", "StatsBase"]
-git-tree-sha1 = "b11c8d607af357776a046889a7c32567d05f1319"
+git-tree-sha1 = "75479b7df4167267d75294d14b58244695beb2ac"
 uuid = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
-version = "0.14.1"
+version = "0.14.2"
+
+[[ColorSchemes]]
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random"]
+git-tree-sha1 = "a851fec56cb73cfdf43762999ec72eff5b86882a"
+uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
+version = "3.15.0"
+
+[[ColorTypes]]
+deps = ["FixedPointNumbers", "Random"]
+git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
+uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
+version = "0.11.0"
+
+[[Colors]]
+deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
+git-tree-sha1 = "417b0ed7b8b838aa6ca0a87aadf1bb9eb111ce40"
+uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
+version = "0.12.8"
 
 [[Combinatorics]]
-deps = ["LinearAlgebra", "Polynomials", "Test"]
-git-tree-sha1 = "50b3ae4d643dc27eaff69fb6be06ee094d5500c9"
+git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
 uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
-version = "0.7.0"
+version = "1.0.2"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "cf03b37436c6bc162e7c8943001568b4cad4bee3"
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.19.0"
+version = "3.41.0"
 
 [[CompilerSupportLibraries_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "7c4f882c41faa72118841185afc58a2eb00ef612"
+deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
-version = "0.3.3+0"
+
+[[CompositionsBase]]
+git-tree-sha1 = "455419f7e328a1a2493cabc6428d79e951349769"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.1"
+
+[[Contour]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "9f02045d934dc030edad45944ea80dbd1f0ebea7"
+uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
+version = "0.5.7"
 
 [[DataAPI]]
-git-tree-sha1 = "176e23402d80e7743fc26c19c681bfb11246af32"
+git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.3.0"
+version = "1.9.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "db07bb22795762895b60e44d62b34b16c982a687"
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.7"
+version = "0.18.11"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -46,27 +119,39 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
+[[DensityInterface]]
+deps = ["InverseFunctions", "Test"]
+git-tree-sha1 = "80c3e8639e3353e5d2912fb3a1916b8455e2494b"
+uuid = "b429d917-457f-4dbc-8f4c-0cc954292b1d"
+version = "0.4.0"
+
 [[DeterminantalPointProcesses]]
-deps = ["Combinatorics", "Distributed", "IterTools", "LinearAlgebra", "Random", "SharedArrays", "Test"]
-git-tree-sha1 = "00bdc4288edb9c1270e5d79c85a376dae64c1669"
+deps = ["Combinatorics", "Distributed", "Distributions", "IterTools", "LinearAlgebra", "Random", "Requires", "SharedArrays", "Test"]
+git-tree-sha1 = "90607d4bc92a8bae044313417e0de8d04e4e8e20"
 uuid = "4d968f93-c0cd-4b7f-b189-b034d1a24a0e"
-version = "0.1.0"
+version = "0.2.2"
 
 [[Distances]]
-deps = ["LinearAlgebra", "Statistics"]
-git-tree-sha1 = "a5b88815e6984e9f3256b6ca0dc63109b16a506f"
+deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "3258d0659f812acde79e8a74b11f17ac06d0ca04"
 uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-version = "0.9.2"
+version = "0.10.7"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
 uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
+[[Distributions]]
+deps = ["ChainRulesCore", "DensityInterface", "FillArrays", "LinearAlgebra", "PDMats", "Printf", "QuadGK", "Random", "SparseArrays", "SpecialFunctions", "Statistics", "StatsBase", "StatsFuns", "Test"]
+git-tree-sha1 = "c1724611e6ae29c6094c8d9850e3136297ba7fff"
+uuid = "31c24e10-a181-5473-b8eb-7969acd0382f"
+version = "0.25.36"
+
 [[DocStringExtensions]]
-deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "50ddf44c53698f5e784bbebb3f4b21c5807401b1"
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.3"
+version = "0.8.6"
 
 [[Documenter]]
 deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
@@ -74,142 +159,504 @@ git-tree-sha1 = "fb1ff838470573adc15c71ba79f8d31328f035da"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 version = "0.25.2"
 
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "3f3a2501fa7236e9b911e0f7a588c657e822bb6d"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.2.3+0"
+
+[[Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.2.10+0"
+
+[[FFMPEG]]
+deps = ["FFMPEG_jll"]
+git-tree-sha1 = "b57e3acbe22f8484b4b5ff66a7499717fe1a9cc8"
+uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
+version = "0.4.1"
+
+[[FFMPEG_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "d8a578692e3077ac998b50c0217dfd67f21d1e5f"
+uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
+version = "4.4.0+0"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
+git-tree-sha1 = "8756f9935b7ccc9064c6eef0bff0ad643df733a3"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.12.7"
+
+[[FixedPointNumbers]]
+deps = ["Statistics"]
+git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
+uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
+version = "0.8.4"
+
+[[Fontconfig_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "21efd19106a55620a188615da6d3d06cd7f6ee03"
+uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
+version = "2.13.93+0"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
+[[FreeType2_jll]]
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "87eb71354d8ec1a96d4a7636bd57a7347dde3ef9"
+uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
+version = "2.10.4+0"
+
+[[FriBidi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
+uuid = "559328eb-81f9-559d-9380-de523a88c83c"
+version = "1.0.10+0"
+
 [[Functors]]
-deps = ["MacroTools"]
-git-tree-sha1 = "f40adc6422f548176bb4351ebd29e4abf773040a"
+git-tree-sha1 = "e4768c3b7f597d5a352afa09874d16e3c3f6ead2"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.1.0"
+version = "0.2.7"
+
+[[GLFW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
+git-tree-sha1 = "0c603255764a1fa0b61752d2bec14cfbd18f7fe8"
+uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+version = "3.3.5+1"
+
+[[GR]]
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "30f2b340c2fff8410d89bfcdc9c0a6dd661ac5f7"
+uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
+version = "0.62.1"
+
+[[GR_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "fd75fa3a2080109a2c0ec9864a6e14c60cca3866"
+uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
+version = "0.62.0+0"
+
+[[GeometryBasics]]
+deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "58bcdf5ebc057b085e58d95c138725628dd7453c"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.4.1"
+
+[[Gettext_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "9b02998aba7bf074d14de89f9d37ca24a1a0b046"
+uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
+version = "0.21.0+0"
+
+[[Glib_jll]]
+deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "74ef6288d071f58033d54fd6708d4bc23a8b8972"
+uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
+version = "2.68.3+1"
+
+[[Graphite2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "344bf40dcab1073aca04aa0df4fb092f920e4011"
+uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
+version = "1.3.14+0"
+
+[[Grisu]]
+git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
+uuid = "42e2da0e-8278-4e71-bc24-59509adca0fe"
+version = "1.0.2"
+
+[[HTTP]]
+deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
+git-tree-sha1 = "0fa77022fe4b511826b39c894c90daf5fce3334a"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "0.9.17"
+
+[[HarfBuzz_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
+git-tree-sha1 = "129acf094d168394e80ee1dc4bc06ec835e510a3"
+uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
+version = "2.8.1+1"
 
 [[InducingPoints]]
-deps = ["Clustering", "DataStructures", "DeterminantalPointProcesses", "Distances", "KernelFunctions", "LinearAlgebra", "Random", "StatsBase"]
+deps = ["AbstractGPs", "Clustering", "DataStructures", "DeterminantalPointProcesses", "Distances", "KernelFunctions", "LinearAlgebra", "Random", "StatsBase"]
 path = ".."
 uuid = "b4bd816d-b975-4295-ac05-5f2992945579"
-version = "0.1.0"
+version = "0.2.8"
+
+[[IniFile]]
+deps = ["Test"]
+git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
+version = "0.5.0"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
+[[InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.2"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
 [[IterTools]]
-git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+git-tree-sha1 = "fa6287a4469f5e048d763df38279ee729fbd44e5"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.4.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.2"
+
+[[JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "2.1.0+0"
 
 [[KernelFunctions]]
-deps = ["Compat", "Distances", "Functors", "InteractiveUtils", "LinearAlgebra", "Random", "Requires", "SpecialFunctions", "StatsBase", "StatsFuns", "Test", "ZygoteRules"]
-git-tree-sha1 = "ce494c70e186d2149bf4e404b50b9d2be8c16847"
+deps = ["ChainRulesCore", "Compat", "CompositionsBase", "Distances", "FillArrays", "Functors", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Random", "Requires", "SpecialFunctions", "StatsBase", "TensorCore", "Test", "ZygoteRules"]
+git-tree-sha1 = "9c3d38dafc02feae68a4747813b8b0205fd03da5"
 uuid = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
-version = "0.8.6"
+version = "0.10.26"
+
+[[LAME_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f6250b16881adf048549549fba48b1161acdac8c"
+uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
+version = "3.100.1+0"
+
+[[LZO_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "e5b909bcf985c5e2605737d2ce278ed791b89be6"
+uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
+version = "2.10.1+0"
+
+[[LaTeXStrings]]
+git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.3.0"
+
+[[Latexify]]
+deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
+git-tree-sha1 = "a8f4f279b6fa3c3c4f1adadd78a621b13a506bce"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.15.9"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
 
 [[LibGit2]]
-deps = ["Printf"]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[[Libffi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "0b4a5d71f3e5200a7dff793393e09dfc2d874290"
+uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+version = "3.2.2+1"
+
+[[Libgcrypt_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
+git-tree-sha1 = "64613c82a59c120435c067c2b809fc61cf5166ae"
+uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
+version = "1.8.7+0"
+
+[[Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "7739f837d6447403596a75d19ed01fd08d6f56bf"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.3.0+3"
+
+[[Libgpg_error_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c333716e46366857753e273ce6a69ee0945a6db9"
+uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
+version = "1.42.0+0"
+
+[[Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.1+1"
+
+[[Libmount_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "9c30530bf0effd46e15e0fdcf2b8636e78cbbd73"
+uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
+version = "2.35.0+0"
+
+[[Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "340e257aada13f95f98ee352d316c3bed37c8ab9"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.3.0+0"
+
+[[Libuuid_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7f3efec06033682db852f8b3bc3c1d2b0a0ab066"
+uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
+version = "2.36.0+0"
+
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.6"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "f7d2e3f654af75f01ec49be82c231c382214223a"
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.5"
+version = "0.5.9"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
+[[MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
+git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.0.3"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[Measures]]
+git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
+uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
+version = "0.3.1"
+
 [[Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "ed61674a0864832495ffe0a7e889c0da76b0f4c8"
+git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "0.4.4"
+version = "1.0.2"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NaNMath]]
+git-tree-sha1 = "f755f36b19a5116bb580de457cda0c140153f283"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.6"
+
 [[NearestNeighbors]]
 deps = ["Distances", "StaticArrays"]
-git-tree-sha1 = "93107e3cdada73d63245ed8170dcae680f0c8fd8"
+git-tree-sha1 = "16baacfdc8758bc374882566c9187e785e85c2f0"
 uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
-version = "0.4.6"
+version = "0.4.9"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Ogg_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "7937eda4681660b4d6aeeecc2f7e1c81c8ee4e2f"
+uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
+version = "1.3.5+0"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "15003dcb7d8db3c6c857fda14891a539a8f2705a"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "1.1.10+0"
 
 [[OpenSpecFun_jll]]
-deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
-git-tree-sha1 = "d51c416559217d974a1113522d5919235ae67a87"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
 uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
-version = "0.5.3+3"
+version = "0.5.5+0"
+
+[[Opus_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51a08fb14ec28da2ec7a927c4337e4332c2a4720"
+uuid = "91d4177d-7536-5919-b921-800302f37372"
+version = "1.3.2+0"
 
 [[OrderedCollections]]
-git-tree-sha1 = "16c08bf5dba06609fe45e30860092d6fa41fde7b"
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-version = "1.3.1"
+version = "1.4.1"
+
+[[PCRE_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b2a7af664e098055a7529ad1a900ded962bca488"
+uuid = "2f80f16e-611a-54ab-bc61-aa92de5b98fc"
+version = "8.44.0+0"
+
+[[PDMats]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "ee26b350276c51697c9c2d88a072b339f9f03d73"
+uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
+version = "0.11.5"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "6fa4202675c05ba0f8268a6ddf07606350eda3ce"
+git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.0.11"
+version = "2.1.3"
+
+[[Pixman_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "b4f5d02549a10e20780a24fce72bea96b6329e29"
+uuid = "30392449-352a-5448-841d-b1acce4e97dc"
+version = "0.40.1+0"
 
 [[Pkg]]
-deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
-[[Polynomials]]
-deps = ["LinearAlgebra", "RecipesBase"]
-git-tree-sha1 = "1185511cac8ab9d0b658b663eae34fe9a95d4332"
-uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "0.6.1"
+[[PlotThemes]]
+deps = ["PlotUtils", "Requires", "Statistics"]
+git-tree-sha1 = "a3a964ce9dc7898193536002a6dd892b1b5a6f1d"
+uuid = "ccf2f8ad-2431-5c83-bf29-c5338b663b6a"
+version = "2.0.1"
+
+[[PlotUtils]]
+deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
+git-tree-sha1 = "e4fe0b50af3130ddd25e793b471cb43d5279e3e6"
+uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
+version = "1.1.1"
+
+[[Plots]]
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun"]
+git-tree-sha1 = "65ebc27d8c00c84276f14aaf4ff63cbe12016c70"
+uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+version = "1.25.2"
+
+[[Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.2"
 
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[Qt5Base_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
+git-tree-sha1 = "ad368663a5e20dbb8d6dc2fddeefe4dae0781ae8"
+uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
+version = "5.15.3+0"
+
+[[QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.2"
+
 [[REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
-git-tree-sha1 = "b4ed4a7f988ea2340017916f7c9e5d7560b52cae"
+git-tree-sha1 = "6bf3f380ff52ce0832ddd3a2a7b9538ed1bcca7d"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "0.8.0"
+version = "1.2.1"
+
+[[RecipesPipeline]]
+deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
+git-tree-sha1 = "7ad0dfa8d03b7bcf8c597f59f5292801730c55b8"
+uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
+version = "0.4.1"
+
+[[Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "28faf1c963ca1dc3ec87f166d92982e3c4a1f66d"
+git-tree-sha1 = "8f82019e525f4d5c669692772a6f4b0a58b06a6a"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.0"
+version = "1.2.0"
 
 [[Rmath]]
 deps = ["Random", "Rmath_jll"]
-git-tree-sha1 = "86c5647b565873641538d8f812c04e4c9dbeb370"
+git-tree-sha1 = "bf3188feca147ce108c76ad82c2792c57abe7b1f"
 uuid = "79098fc4-a85e-5d69-aa6a-4863f24498fa"
-version = "0.6.1"
+version = "0.7.0"
 
 [[Rmath_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "d76185aa1f421306dec73c057aa384bad74188f0"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "68db32dff12bb6127bac73c209881191bf0efbb7"
 uuid = "f50d1b31-88e8-58de-be2c-1cc44531875f"
-version = "0.2.2+1"
+version = "0.3.0+0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.1.0"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -218,50 +665,102 @@ uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 deps = ["Distributed", "Mmap", "Random", "Serialization"]
 uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
+[[Showoff]]
+deps = ["Dates", "Grisu"]
+git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
+uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
+version = "1.0.3"
+
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[SortingAlgorithms]]
-deps = ["DataStructures", "Random", "Test"]
-git-tree-sha1 = "03f5898c9959f8115e30bc7226ada7d0df554ddd"
+deps = ["DataStructures"]
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "0.3.1"
+version = "1.0.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["OpenSpecFun_jll"]
-git-tree-sha1 = "d8d8b8a9f4119829410ecd706da4cc8594a1e020"
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "f0bccf98e16759818ffc5d97ac3ebf87eb950150"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "0.10.3"
+version = "1.8.1"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "016d1e1a00fabc556473b07161da3d39726ded35"
+git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.12.4"
+version = "1.2.13"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
+[[StatsAPI]]
+git-tree-sha1 = "0f2aa8e32d511f758a2ce49208181f7733a0936a"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.1.0"
+
 [[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics"]
-git-tree-sha1 = "7bab7d4eb46b225b35179632852b595a3162cb61"
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "2bb0cb32026a66037360606510fca5984ccc6b75"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.2"
+version = "0.33.13"
 
 [[StatsFuns]]
-deps = ["Rmath", "SpecialFunctions"]
-git-tree-sha1 = "04a5a8e6ab87966b43f247920eab053fd5fdc925"
+deps = ["ChainRulesCore", "InverseFunctions", "IrrationalConstants", "LogExpFunctions", "Reexport", "Rmath", "SpecialFunctions"]
+git-tree-sha1 = "bedb3e17cc1d94ce0e6e66d3afa47157978ba404"
 uuid = "4c63d2b9-4356-54db-8cca-17b64c39e42c"
-version = "0.9.5"
+version = "0.9.14"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
+git-tree-sha1 = "2ce41e0d042c60ecd131e9fb7154a3bfadbf50d3"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.6.3"
+
+[[SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "bb1064c9a84c52e277f1096cf41434b675cd368b"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.6.1"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[TensorCore]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "1feb45f88d133a655e001435632f019a9a1bcdb6"
+uuid = "62fd8b95-f654-4bbd-a8a5-9c27f68ccd50"
+version = "0.1.1"
 
 [[Test]]
-deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[URIs]]
+git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.3.0"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -270,8 +769,228 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[UnicodeFun]]
+deps = ["REPL"]
+git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
+uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+version = "0.4.1"
+
+[[Wayland_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "3e61f0b86f90dacb0bc0e73a0c5a83f6a8636e23"
+uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
+version = "1.19.0+0"
+
+[[Wayland_protocols_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "66d72dc6fcc86352f01676e8f0f698562e60510f"
+uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
+version = "1.23.0+0"
+
+[[XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.9.12+0"
+
+[[XSLT_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]
+git-tree-sha1 = "91844873c4085240b95e795f692c4cec4d805f8a"
+uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
+version = "1.1.34+0"
+
+[[Xorg_libX11_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "5be649d550f3f4b95308bf0183b82e2582876527"
+uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
+version = "1.6.9+4"
+
+[[Xorg_libXau_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4e490d5c960c314f33885790ed410ff3a94ce67e"
+uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
+version = "1.0.9+4"
+
+[[Xorg_libXcursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "12e0eb3bc634fa2080c1c37fccf56f7c22989afd"
+uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
+version = "1.2.0+4"
+
+[[Xorg_libXdmcp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4fe47bd2247248125c428978740e18a681372dd4"
+uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
+version = "1.1.3+4"
+
+[[Xorg_libXext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "b7c0aa8c376b31e4852b360222848637f481f8c3"
+uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
+version = "1.3.4+4"
+
+[[Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "0e0dc7431e7a0587559f9294aeec269471c991a4"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "5.0.3+4"
+
+[[Xorg_libXi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
+git-tree-sha1 = "89b52bc2160aadc84d707093930ef0bffa641246"
+uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
+version = "1.7.10+4"
+
+[[Xorg_libXinerama_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll"]
+git-tree-sha1 = "26be8b1c342929259317d8b9f7b53bf2bb73b123"
+uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
+version = "1.1.4+4"
+
+[[Xorg_libXrandr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "34cea83cb726fb58f325887bf0612c6b3fb17631"
+uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
+version = "1.5.2+4"
+
+[[Xorg_libXrender_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "19560f30fd49f4d4efbe7002a1037f8c43d43b96"
+uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
+version = "0.9.10+4"
+
+[[Xorg_libpthread_stubs_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6783737e45d3c59a4a4c4091f5f88cdcf0908cbb"
+uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
+version = "0.1.0+3"
+
+[[Xorg_libxcb_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
+git-tree-sha1 = "daf17f441228e7a3833846cd048892861cff16d6"
+uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
+version = "1.13.0+3"
+
+[[Xorg_libxkbfile_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "926af861744212db0eb001d9e40b5d16292080b2"
+uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
+version = "1.1.0+4"
+
+[[Xorg_xcb_util_image_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "0fab0a40349ba1cba2c1da699243396ff8e94b97"
+uuid = "12413925-8142-5f55-bb0e-6d7ca50bb09b"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll"]
+git-tree-sha1 = "e7fd7b2881fa2eaa72717420894d3938177862d1"
+uuid = "2def613f-5ad1-5310-b15b-b15d46f528f5"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_keysyms_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "d1151e2c45a544f32441a567d1690e701ec89b00"
+uuid = "975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_renderutil_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "dfd7a8f38d4613b6a575253b3174dd991ca6183e"
+uuid = "0d47668e-0667-5a69-a72c-f761630bfb7e"
+version = "0.3.9+1"
+
+[[Xorg_xcb_util_wm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "e78d10aab01a4a154142c5006ed44fd9e8e31b67"
+uuid = "c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+version = "0.4.1+1"
+
+[[Xorg_xkbcomp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxkbfile_jll"]
+git-tree-sha1 = "4bcbf660f6c2e714f87e960a171b119d06ee163b"
+uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
+version = "1.4.2+4"
+
+[[Xorg_xkeyboard_config_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xkbcomp_jll"]
+git-tree-sha1 = "5c8424f8a67c3f2209646d4425f3d415fee5931d"
+uuid = "33bec58e-1273-512f-9401-5d533626f822"
+version = "2.27.0+4"
+
+[[Xorg_xtrans_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "79c31e7844f6ecf779705fbc12146eb190b7d845"
+uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
+version = "1.4.0+3"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "cc4bf3fdde8b7e3e9fa0351bdeedba1cf3b7f6e6"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.0+0"
+
 [[ZygoteRules]]
 deps = ["MacroTools"]
-git-tree-sha1 = "b3b4882cc9accf6731a08cc39543fbc6b669dca8"
+git-tree-sha1 = "8c1a8e4dfacb1fd631745552c8db35d0deb09ea0"
 uuid = "700de1a5-db45-46bc-99cf-38207098b444"
-version = "0.2.0"
+version = "0.2.2"
+
+[[libass_jll]]
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "5982a94fcba20f02f42ace44b9894ee2b140fe47"
+uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
+version = "0.15.1+0"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[libfdk_aac_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "daacc84a041563f965be61859a36e17c4e4fcd55"
+uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
+version = "2.0.2+0"
+
+[[libpng_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "94d180a6d2b5e55e447e2d27a29ed04fe79eb30c"
+uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+version = "1.6.38+0"
+
+[[libvorbis_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
+git-tree-sha1 = "c45f4e40e7aafe9d086379e5578947ec8b95a8fb"
+uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
+version = "1.3.7+0"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+
+[[x264_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4fea590b89e6ec504593146bf8b988b2c00922b2"
+uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
+version = "2021.5.5+0"
+
+[[x265_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "ee567a171cce03570d77ad3a43e90218e38937a9"
+uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
+version = "3.5.0+0"
+
+[[xkbcommon_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
+git-tree-sha1 = "ece2350174195bb31de1a63bea3a41ae1aa593b6"
+uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+version = "0.9.1+5"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -18,8 +18,26 @@ uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
+[[AssetRegistry]]
+deps = ["Distributed", "JSON", "Pidfile", "SHA", "Test"]
+git-tree-sha1 = "b25e88db7944f98789130d7b503276bc34bc098e"
+uuid = "bf4720bc-e11a-5d0c-854e-bdca1663c893"
+version = "0.1.0"
+
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BinDeps]]
+deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
+git-tree-sha1 = "1289b57e8cf019aede076edab0587eb9644175bd"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "1.0.2"
+
+[[Blink]]
+deps = ["Base64", "BinDeps", "Distributed", "JSExpr", "JSON", "Lazy", "Logging", "MacroTools", "Mustache", "Mux", "Reexport", "Sockets", "WebIO", "WebSockets"]
+git-tree-sha1 = "08d0b679fd7caa49e2bca9214b131289e19808c0"
+uuid = "ad839575-38b3-5650-b840-f874b8c74a25"
+version = "0.12.5"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -29,9 +47,9 @@ version = "1.0.8+0"
 
 [[Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "f2202b55d816427cd385a9a4f3ffb226bee80f99"
+git-tree-sha1 = "4b859a208b2397a7a623a03449e4636bdb17bcf2"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
-version = "1.16.1+0"
+version = "1.16.1+1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
@@ -187,6 +205,9 @@ git-tree-sha1 = "d8a578692e3077ac998b50c0217dfd67f21d1e5f"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
 version = "4.4.0+0"
 
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
 [[FillArrays]]
 deps = ["LinearAlgebra", "Random", "SparseArrays", "Statistics"]
 git-tree-sha1 = "8756f9935b7ccc9064c6eef0bff0ad643df733a3"
@@ -222,6 +243,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
 version = "1.0.10+0"
+
+[[FunctionalCollections]]
+deps = ["Test"]
+git-tree-sha1 = "04cb9cfaa6ba5311973994fe3496ddec19b6292a"
+uuid = "de31a74c-ac4f-5751-b3fd-e18cd04993ca"
+version = "0.5.0"
 
 [[Functors]]
 git-tree-sha1 = "e4768c3b7f597d5a352afa09874d16e3c3f6ead2"
@@ -260,9 +287,9 @@ version = "0.21.0+0"
 
 [[Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "74ef6288d071f58033d54fd6708d4bc23a8b8972"
+git-tree-sha1 = "a32d672ac2c967f3deb8a81d828afc739c838a06"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.68.3+1"
+version = "2.68.3+2"
 
 [[Graphite2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -286,6 +313,12 @@ deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll",
 git-tree-sha1 = "129acf094d168394e80ee1dc4bc06ec835e510a3"
 uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
 version = "2.8.1+1"
+
+[[Hiccup]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "6187bb2d5fcbb2007c39e7ac53308b0d371124bd"
+uuid = "9fb69e20-1954-56bb-a84f-559cc56a8ff7"
+version = "0.2.2"
 
 [[InducingPoints]]
 deps = ["AbstractGPs", "Clustering", "DataStructures", "DeterminantalPointProcesses", "Distances", "KernelFunctions", "LinearAlgebra", "Random", "StatsBase"]
@@ -330,6 +363,12 @@ git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.3.0"
 
+[[JSExpr]]
+deps = ["JSON", "MacroTools", "Observables", "WebIO"]
+git-tree-sha1 = "bd6c034156b1e7295450a219c4340e32e50b08b1"
+uuid = "97c1335a-c9c5-57fe-bc5d-ec35cebe8660"
+version = "0.5.3"
+
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
 git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
@@ -341,6 +380,12 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
 version = "2.1.0+0"
+
+[[Kaleido_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "2ef87eeaa28713cb010f9fb0be288b6c1a4ecd53"
+uuid = "f7e6163d-2fa5-5f23-b69c-1db539e41963"
+version = "0.1.0+0"
 
 [[KernelFunctions]]
 deps = ["ChainRulesCore", "Compat", "CompositionsBase", "Distances", "FillArrays", "Functors", "IrrationalConstants", "LinearAlgebra", "LogExpFunctions", "Random", "Requires", "SpecialFunctions", "StatsBase", "TensorCore", "Test", "ZygoteRules"]
@@ -370,6 +415,12 @@ deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdow
 git-tree-sha1 = "a8f4f279b6fa3c3c4f1adadd78a621b13a506bce"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 version = "0.15.9"
+
+[[Lazy]]
+deps = ["MacroTools"]
+git-tree-sha1 = "1370f8202dac30758f3c345f9909b97f53d87d3f"
+uuid = "50d2b5c4-7a5e-59d5-8109-a42b560f39c0"
+version = "0.15.1"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -488,6 +539,18 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
+[[Mustache]]
+deps = ["Printf", "Tables"]
+git-tree-sha1 = "21d7a05c3b94bcf45af67beccab4f2a1f4a3c30a"
+uuid = "ffc61752-8dc7-55ee-8c37-f3e9cdd09e70"
+version = "1.0.12"
+
+[[Mux]]
+deps = ["AssetRegistry", "Base64", "HTTP", "Hiccup", "Pkg", "Sockets", "WebSockets"]
+git-tree-sha1 = "82dfb2cead9895e10ee1b0ca37a01088456c4364"
+uuid = "a975b10e-0019-58db-a62f-e48ff68538c9"
+version = "0.7.6"
+
 [[NaNMath]]
 git-tree-sha1 = "f755f36b19a5116bb580de457cda0c140153f283"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -501,6 +564,11 @@ version = "0.4.9"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Observables]]
+git-tree-sha1 = "fe29afdef3d0c4a8286128d4e45cc50621b1e43d"
+uuid = "510215fc-4207-5dde-b226-833fc4488ee2"
+version = "0.4.0"
 
 [[Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -551,11 +619,23 @@ git-tree-sha1 = "ee26b350276c51697c9c2d88a072b339f9f03d73"
 uuid = "90014a1f-27ba-587c-ab20-58faa44d9150"
 version = "0.11.5"
 
+[[Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.3"
+
 [[Parsers]]
 deps = ["Dates"]
 git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "2.1.3"
+
+[[Pidfile]]
+deps = ["FileWatching", "Test"]
+git-tree-sha1 = "1be8660b2064893cd2dae4bd004b589278e4440d"
+uuid = "fa939f87-e72e-5be4-a000-7fc836dbe307"
+version = "1.2.0"
 
 [[Pixman_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -578,6 +658,18 @@ deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Stat
 git-tree-sha1 = "e4fe0b50af3130ddd25e793b471cb43d5279e3e6"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.1.1"
+
+[[PlotlyBase]]
+deps = ["ColorSchemes", "Dates", "DelimitedFiles", "DocStringExtensions", "JSON", "LaTeXStrings", "Logging", "Parameters", "Pkg", "REPL", "Requires", "Statistics", "UUIDs"]
+git-tree-sha1 = "180d744848ba316a3d0fdf4dbd34b77c7242963a"
+uuid = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
+version = "0.8.18"
+
+[[PlotlyJS]]
+deps = ["Base64", "Blink", "DelimitedFiles", "JSExpr", "JSON", "Kaleido_jll", "Markdown", "Pkg", "PlotlyBase", "REPL", "Reexport", "Requires", "WebIO"]
+git-tree-sha1 = "53d6325e14d3bdb85fd387a085075f36082f35a3"
+uuid = "f0f68f2c-4968-5e81-91da-67840de0976a"
+version = "0.18.8"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun"]
@@ -757,6 +849,12 @@ version = "0.1.1"
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
+[[URIParser]]
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.1"
+
 [[URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
 uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
@@ -765,6 +863,11 @@ version = "1.3.0"
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
@@ -786,6 +889,24 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "66d72dc6fcc86352f01676e8f0f698562e60510f"
 uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
 version = "1.23.0+0"
+
+[[WebIO]]
+deps = ["AssetRegistry", "Base64", "Distributed", "FunctionalCollections", "JSON", "Logging", "Observables", "Pkg", "Random", "Requires", "Sockets", "UUIDs", "WebSockets", "Widgets"]
+git-tree-sha1 = "5fe32e4086d49f7ab9b087296742859f3ae6d62a"
+uuid = "0f1e0344-ec1d-5b48-a673-e5cf874b6c29"
+version = "0.8.16"
+
+[[WebSockets]]
+deps = ["Base64", "Dates", "HTTP", "Logging", "Sockets"]
+git-tree-sha1 = "f91a602e25fe6b89afc93cf02a4ae18ee9384ce3"
+uuid = "104b5d7c-a370-577a-8038-80a2059c5097"
+version = "1.5.9"
+
+[[Widgets]]
+deps = ["Colors", "Dates", "Observables", "OrderedCollections"]
+git-tree-sha1 = "80661f59d28714632132c73779f8becc19a113f2"
+uuid = "cc8bc4a8-27d6-5769-a93b-9d913e69aa62"
+version = "0.6.4"
 
 [[XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,5 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InducingPoints = "b4bd816d-b975-4295-ac05-5f2992945579"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
+PlotlyJS = "f0f68f2c-4968-5e81-91da-67840de0976a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,5 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InducingPoints = "b4bd816d-b975-4295-ac05-5f2992945579"
+KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,9 +13,7 @@ makedocs(;
         canonical="https://JuliaGaussianProcesses.github.io/InducingPoints.jl",
         assets=String[],
     ),
-    pages=["Home" => "index.md",
-    "Algorithms" => "algorithms.md",
-    "API" => "api.md"],
+    pages=["Home" => "index.md", "Algorithms" => "algorithms.md", "API" => "api.md"],
 )
 
 deploydocs(; repo="github.com/JuliaGaussianProcesses/InducingPoints.jl")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(;
         canonical="https://JuliaGaussianProcesses.github.io/InducingPoints.jl",
         assets=String[],
     ),
+    strict=true,
     pages=["Home" => "index.md", "Algorithms" => "algorithms.md", "API" => "api.md"],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,8 @@
 using InducingPoints
 using Documenter
 
+ENV["GKSwstype"] = "100"
+
 makedocs(;
     modules=[InducingPoints],
     authors="Theo Galy-Fajou <theo.galyfajou@gmail.com> and contributors",
@@ -11,7 +13,9 @@ makedocs(;
         canonical="https://JuliaGaussianProcesses.github.io/InducingPoints.jl",
         assets=String[],
     ),
-    pages=["Home" => "index.md"],
+    pages=["Home" => "index.md",
+    "Algorithms" => "algorithms.md",
+    "API" => "api.md"],
 )
 
 deploydocs(; repo="github.com/JuliaGaussianProcesses/InducingPoints.jl")

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -1,0 +1,90 @@
+```@setup base
+using Random: seed!
+seed!(42)
+using KernelFunctions
+using Plots
+using InducingPoints
+D = 2
+N = 50
+M = 10
+x = [rand(D) for _ in 1:N]
+
+function plot_inducing_points(x,Z)
+    p = scatter(getindex.(x, 1), getindex.(x, 2), 
+        label = "Original Data",
+        color = :black, 
+        markersize = 6,
+        markerstrokewidth = 0,
+        xlims = [0, 1.], ylims = [0., 1.])
+    scatter!(p, getindex.(Z,1), getindex.(Z, 2), 
+        marker = :star5, 
+        markersize = 6, 
+        color = :orangered3,
+        label = "Inducing Points")
+        return p
+end
+```
+
+# Available Algorithms {.unlisted .unnumbered}
+
+The algorithms available through InducingPoints.jl can be split into offline and online use. 
+While all algorithms can be used to create one-off sets of inducing points, the online algorithms are designed in a way that allows for cheap updating. 
+
+```@contents
+    Pages = ["algorithms.md"]
+    Depth = 3
+```
+
+## Offline Algorithms
+
+### [`KmeansAlg`](@ref) 
+Uses the k-means algorithm to select centroids minimizing the square distance with the dataset. The seeding is done via `k-means++`. Note that the inducing points are not going to be a subset of the data. 
+
+```@example base
+alg = KmeansAlg(M)
+Z = inducingpoints(alg, x)
+plot_inducing_points(x,Z) #hide
+savefig("kmeans.svg"); nothing # hide
+```
+![](kmeans.svg)
+
+
+
+### [`kDPP`](@ref)
+Sample from a k-Determinantal Point Process to select `k` points. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
+
+```@example base
+kernel = SqExponentialKernel()
+alg = kDPP(M, kernel)
+Z = inducingpoints(alg, x)
+plot_inducing_points(x,Z) #hide
+savefig("kdpp.svg"); nothing # hide
+```
+![](kdpp.svg)
+
+### [`StdDPP`](@ref)
+Samples from a standard Determinantal Point Process. The number of inducing points is not fixed here. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
+
+```@example base
+kernel = SqExponentialKernel()
+alg = StdDPP(kernel)
+Z = inducingpoints(alg, x)
+plot_inducing_points(x,Z) #hide
+savefig("StdDPP.svg"); nothing # hide
+```
+![](StdDPP.svg)
+
+### [`RandomSubset`](@ref)
+Sample randomly `k` points from the data set uniformly.
+
+```@example base
+alg = RandomSubset(M)
+Z = inducingpoints(alg, x)
+plot_inducing_points(x,Z) #hide
+savefig("RandomSubset.svg"); nothing # hide
+```
+![](RandomSubset.svg)
+
+
+### [`Greedy`](@ref) 
+This algorithm will select a subset of `X` which maximizes the `ELBO` (in a stochastic way)

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -8,24 +8,37 @@ D = 2
 N = 50
 M = 10
 x = [rand(D) for _ in 1:N]
+N₂ = 25
+x₂ = [rand(D) for _ in 1:N₂] .* 0.25
 
-function plot_inducing_points(x,Z)
+function plot_inducing_points(x,Z, x₂ = nothing, Z₂=nothing)
     p = scatter(getindex.(x, 1), getindex.(x, 2), 
         label = "Original Data",
         color = :black, 
         markersize = 6,
         markerstrokewidth = 0,
         xlims = [0, 1.], ylims = [0., 1.])
+
     scatter!(p, getindex.(Z,1), getindex.(Z, 2), 
-        marker = :star5, 
+        marker = :star6, 
         markersize = 6, 
         color = :orangered3,
-        label = "Inducing Points")
-        return p
+        label = "Inducing Points Z")
+        
+    if !isnothing(Z₂)
+        scatter!(p, getindex.(x₂,1), getindex.(x₂, 2), 
+            markersize = 6, 
+            color = :grey42,
+            label = "Additional Data")
+        scatter!(p, getindex.(Z₂,1), getindex.(Z₂, 2), 
+            marker = :xcross, 
+            markersize = 6, 
+            color = :seagreen,
+            label = "Updated Z")
+    end
+    return p
 end
 ```
-
-# Available Algorithms {.unlisted .unnumbered}
 
 The algorithms available through InducingPoints.jl can be split into offline and online use. 
 While all algorithms can be used to create one-off sets of inducing points, the online algorithms are designed in a way that allows for cheap updating. 
@@ -35,56 +48,106 @@ While all algorithms can be used to create one-off sets of inducing points, the 
     Depth = 3
 ```
 
-## Offline Algorithms
+Generally, we start with a set of `N` data points of dimension `D`, which we would like to reduce to only `M < N ` points.
 
-### [`KmeansAlg`](@ref) 
+```@example
+D = 2
+N = 50
+M = 10
+x = [rand(D) for _ in 1:N]
+nothing # hide
+```
+
+# Offline Algorithms
+
+## [`KmeansAlg`](@ref) 
 Uses the k-means algorithm to select centroids minimizing the square distance with the dataset. The seeding is done via `k-means++`. Note that the inducing points are not going to be a subset of the data. 
 
 ```@example base
 alg = KmeansAlg(M)
 Z = inducingpoints(alg, x)
-plot_inducing_points(x,Z) #hide
+plot_inducing_points(x, Z) #hide
 savefig("kmeans.svg"); nothing # hide
 ```
 ![](kmeans.svg)
 
 
 
-### [`kDPP`](@ref)
+## [`kDPP`](@ref)
 Sample from a k-Determinantal Point Process to select `k` points. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
 
 ```@example base
 kernel = SqExponentialKernel()
 alg = kDPP(M, kernel)
 Z = inducingpoints(alg, x)
-plot_inducing_points(x,Z) #hide
+plot_inducing_points(x, Z) #hide
 savefig("kdpp.svg"); nothing # hide
 ```
 ![](kdpp.svg)
 
-### [`StdDPP`](@ref)
+## [`StdDPP`](@ref)
 Samples from a standard Determinantal Point Process. The number of inducing points is not fixed here. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
 
 ```@example base
 kernel = SqExponentialKernel()
 alg = StdDPP(kernel)
 Z = inducingpoints(alg, x)
-plot_inducing_points(x,Z) #hide
+plot_inducing_points(x, Z) #hide
 savefig("StdDPP.svg"); nothing # hide
 ```
 ![](StdDPP.svg)
 
-### [`RandomSubset`](@ref)
+## [`RandomSubset`](@ref)
 Sample randomly `k` points from the data set uniformly.
 
 ```@example base
 alg = RandomSubset(M)
 Z = inducingpoints(alg, x)
-plot_inducing_points(x,Z) #hide
+plot_inducing_points(x, Z) #hide
 savefig("RandomSubset.svg"); nothing # hide
 ```
 ![](RandomSubset.svg)
 
 
-### [`Greedy`](@ref) 
-This algorithm will select a subset of `X` which maximizes the `ELBO` (in a stochastic way)
+## [`Greedy`](@ref) 
+This algorithm will select a subset of `X` which maximizes the `ELBO` (Evidence Lower BOund), which is done in a stochastic way via minibatches of size `s`. This also requires passing the output data, the kernel and the noise level as additional arguments to `inducingpoints`.
+
+```@example base
+y = rand(N)
+s = 5
+kernel = SqExponentialKernel()
+noise = 0.1
+alg = Greedy(M, s)
+Z = inducingpoints(alg, x; y = y, kernel = kernel, noise = noise)
+plot_inducing_points(x, Z) #hide
+savefig("Greedy.svg"); nothing # hide
+```
+![](Greedy.svg)
+
+
+
+# Online Algorithms
+
+These algorithms are useful if we assume that we will have another set of data points that we would like to incorporate into an existing inducing point set. 
+
+```@example
+D = 2 # hide
+N₂ = 25
+x₂ = [rand(D) for _ in 1:N₂] .* 0.25
+nothing # hide
+```
+We can then update the inital set of inducing points `Z` via 
+[`updateZ`](@ref) (or inplace via [`updateZ!`](@ref)).
+
+## [`OnlineIPSelection`](@ref) 
+A method based on distance between inducing points and data. This algorithm has several parameters to tune the result. It also requires the kernel to be passed as a keyword argument to `inducingpoints` and `updateZ`.
+
+```@example base
+kernel = SqExponentialKernel() ∘ ScaleTransform(4.0)
+alg = OIPS()
+Z = inducingpoints(alg, x; kernel = kernel)
+Z₂ = updateZ(Z, alg, x₂; kernel = kernel)
+plot_inducing_points(x, Z, x₂, Z₂) #hide
+savefig("OIPS.svg"); nothing # hide
+```
+![](OIPS.svg)

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -58,7 +58,7 @@ We start with a set of `N` data points of dimension `D`, which we would like to 
 D = 2
 N = 50
 M = 10
-x = [rand(D) for _ in 1:N]
+x = [rand(D) .* [0.8, 1.0] for _ in 1:N]
 nothing # hide
 ```
 
@@ -137,7 +137,7 @@ These algorithms are useful if we assume that we will have another set of data p
 ```@example
 D = 2 # hide
 N₂ = 25
-x₂ = [rand(D) for _ in 1:N₂] .* 0.25
+x₂ = [rand(D) .* [0.2, 1.0] + [0.8, 0.0] for _ in 1:N₂]
 nothing # hide
 ```
 We can then update the inital set of inducing points `Z` via 

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -8,9 +8,9 @@ using InducingPoints
 D = 2
 N = 50
 M = 10
-x = [rand(D) for _ in 1:N]
+x = [rand(D) .* [0.8, 1.0] for _ in 1:N]
 N₂ = 25
-x₂ = [rand(D) for _ in 1:N₂] .* 0.25
+x₂ = [rand(D) .* [0.2, 1.0] + [0.8, 0.0] for _ in 1:N₂]
 
 function plot_inducing_points(x,Z, x₂ = nothing, Z₂=nothing)
     p = scatter(getindex.(x, 1), getindex.(x, 2), 

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -40,6 +40,9 @@ function plot_inducing_points(x,Z, x₂ = nothing, Z₂=nothing)
 end
 ```
 
+# Available Algorithms
+
+
 The algorithms available through InducingPoints.jl can be split into offline and online use. 
 While all algorithms can be used to create one-off sets of inducing points, the online algorithms are designed in a way that allows for cheap updating. 
 
@@ -48,7 +51,7 @@ While all algorithms can be used to create one-off sets of inducing points, the 
     Depth = 3
 ```
 
-Generally, we start with a set of `N` data points of dimension `D`, which we would like to reduce to only `M < N ` points.
+We start with a set of `N` data points of dimension `D`, which we would like to reduce to only `M < N ` points.
 
 ```@example
 D = 2
@@ -58,9 +61,9 @@ x = [rand(D) for _ in 1:N]
 nothing # hide
 ```
 
-# Offline Algorithms
+## Offline Algorithms
 
-## [`KmeansAlg`](@ref) 
+### [`KmeansAlg`](@ref) 
 Uses the k-means algorithm to select centroids minimizing the square distance with the dataset. The seeding is done via `k-means++`. Note that the inducing points are not going to be a subset of the data. 
 
 ```@example base
@@ -73,7 +76,7 @@ savefig("kmeans.svg"); nothing # hide
 
 
 
-## [`kDPP`](@ref)
+### [`kDPP`](@ref)
 Sample from a k-Determinantal Point Process to select `k` points. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
 
 ```@example base
@@ -85,7 +88,7 @@ savefig("kdpp.svg"); nothing # hide
 ```
 ![](kdpp.svg)
 
-## [`StdDPP`](@ref)
+### [`StdDPP`](@ref)
 Samples from a standard Determinantal Point Process. The number of inducing points is not fixed here. `Z` will be a subset of `X`. Requires a kernel from [KernelFunctions.jl](https://juliagaussianprocesses.github.io/KernelFunctions.jl/stable/kernels/)
 
 ```@example base
@@ -97,7 +100,7 @@ savefig("StdDPP.svg"); nothing # hide
 ```
 ![](StdDPP.svg)
 
-## [`RandomSubset`](@ref)
+### [`RandomSubset`](@ref)
 Sample randomly `k` points from the data set uniformly.
 
 ```@example base
@@ -109,7 +112,7 @@ savefig("RandomSubset.svg"); nothing # hide
 ![](RandomSubset.svg)
 
 
-## [`Greedy`](@ref) 
+### [`Greedy`](@ref) 
 This algorithm will select a subset of `X` which maximizes the `ELBO` (Evidence Lower BOund), which is done in a stochastic way via minibatches of size `s`. This also requires passing the output data, the kernel and the noise level as additional arguments to `inducingpoints`.
 
 ```@example base
@@ -126,7 +129,7 @@ savefig("Greedy.svg"); nothing # hide
 
 
 
-# Online Algorithms
+## Online Algorithms
 
 These algorithms are useful if we assume that we will have another set of data points that we would like to incorporate into an existing inducing point set. 
 
@@ -139,7 +142,7 @@ nothing # hide
 We can then update the inital set of inducing points `Z` via 
 [`updateZ`](@ref) (or inplace via [`updateZ!`](@ref)).
 
-## [`OnlineIPSelection`](@ref) 
+### [`OnlineIPSelection`](@ref InducingPoints.OnlineIPSelection)
 A method based on distance between inducing points and data. This algorithm has several parameters to tune the result. It also requires the kernel to be passed as a keyword argument to `inducingpoints` and `updateZ`.
 
 ```@example base
@@ -151,3 +154,55 @@ plot_inducing_points(x, Z, x₂, Z₂) #hide
 savefig("OIPS.svg"); nothing # hide
 ```
 ![](OIPS.svg)
+
+### [`UniGrid`](@ref) 
+A regularly-spaced grid whose edges are adapted given the data.
+
+```@example base
+alg = UniGrid(5)
+Z = inducingpoints(alg, x)
+Z₂ = updateZ(Z, alg, x₂)
+plot_inducing_points(x, Z, x₂, Z₂) #hide
+savefig("UniGrid.svg"); nothing # hide
+```
+![](UniGrid.svg)
+
+
+### [`SeqDPP`](@ref) 
+Sequential Determinantal Point Processes, subsets are regularly sampled from the new data batches conditioned on the existing inducing points.
+
+```@example base
+kernel = SqExponentialKernel()
+alg = SeqDPP()
+Z = inducingpoints(alg, x; kernel = kernel)
+Z₂ = updateZ(Z, alg, x₂; kernel = kernel)
+plot_inducing_points(x, Z, x₂, Z₂) #hide
+savefig("SeqDPP.svg"); nothing # hide
+```
+![](SeqDPP.svg)
+
+
+### [`StreamKmeans`](@ref) 
+An online version of k-means.
+
+```@example base
+alg = StreamKmeans(M)
+Z = inducingpoints(alg, x)
+Z₂ = updateZ(Z, alg, x₂)
+plot_inducing_points(x, Z, x₂, Z₂) #hide
+savefig("StreamKmeans.svg"); nothing # hide
+```
+![](StreamKmeans.svg)
+
+
+### [`Webscale`](@ref) 
+Another online version of k-means
+
+```@example base
+alg = Webscale(M)
+Z = inducingpoints(alg, x)
+Z₂ = updateZ(Z, alg, x₂)
+plot_inducing_points(x, Z, x₂, Z₂) #hide
+savefig("Webscale.svg"); nothing # hide
+```
+![](Webscale.svg)

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -3,6 +3,7 @@ using Random: seed!
 seed!(42)
 using KernelFunctions
 using Plots
+plotlyjs()
 using InducingPoints
 D = 2
 N = 50
@@ -15,24 +16,24 @@ function plot_inducing_points(x,Z, x₂ = nothing, Z₂=nothing)
     p = scatter(getindex.(x, 1), getindex.(x, 2), 
         label = "Original Data",
         color = :black, 
-        markersize = 6,
+        markersize = 7,
         markerstrokewidth = 0,
         xlims = [0, 1.], ylims = [0., 1.])
 
     scatter!(p, getindex.(Z,1), getindex.(Z, 2), 
-        marker = :star6, 
-        markersize = 6, 
+        marker = :xcross, 
+        markersize = 4, 
         color = :orangered3,
         label = "Inducing Points Z")
         
     if !isnothing(Z₂)
         scatter!(p, getindex.(x₂,1), getindex.(x₂, 2), 
-            markersize = 6, 
+            markersize = 7, 
             color = :grey42,
             label = "Additional Data")
         scatter!(p, getindex.(Z₂,1), getindex.(Z₂, 2), 
-            marker = :xcross, 
-            markersize = 6, 
+            marker = :cross, 
+            markersize = 4, 
             color = :seagreen,
             label = "Updated Z")
     end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -1,0 +1,4 @@
+# API
+```@autodocs
+Modules = [InducingPoints]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -2,13 +2,11 @@
 CurrentModule = InducingPoints
 ```
 
-# InducingPoints
+# Intro
 
-InducingPoints.jl aims at providing an easy way to select inducing points locations for Sparse Gaussian Processes both in an online and offline setting.
+InducingPoints.jl aims at providing an easy way to select inducing points locations for Sparse Gaussian Processes both in an online and offline setting. These most used most prominently in sparse GP regression (see e.g. [`ApproximateGPs.jl](https://github.com/JuliaGaussianProcesses/ApproximateGPs.jl))
 
-The point selection is split in the online (`OnIPSA`) and offline settings.
-
-All algorithms inherit from `AbstractInducingPointsSelection` or `AIPSA` which can be passed to the different APIs
+All algorithms inherit from `AbstractInducingPointsSelection` or `AIPSA` which can be passed to the different APIs.
 
 ## Offline Inducing Points Selection
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -48,7 +48,3 @@ The Online options are:
 ```@index
 ```
 
-## API
-```@autodocs
-Modules = [InducingPoints]
-```

--- a/src/InducingPoints.jl
+++ b/src/InducingPoints.jl
@@ -50,12 +50,10 @@ const OnIPSA = OnlineInducingPointsSelectionAlg
 
 ## Wrapper for matrices
 """
-     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractVector; 
-        [y::AbstractVector, kernel::Kernel, noise::Real])
-     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractMatrix; 
-        obsdim=1, [y::AbstractVector, kernel::Kernel, noise::Real])
+     inducingpoints([rng::AbstractRNG], alg::AIPSA, X::AbstractVector; [kwargs...])
+     inducingpoints([rng::AbstractRNG], alg::AIPSA, X::AbstractMatrix; obsdim=1, [kwargs...])
 
-Select inducing points according to the algorithm `alg`. The `kernel` keyword argument is required for the `Greedy`, `OnlineIPSelection`, `SeqDPP` algorithms. The `y` and `noise` keyword arguments are required for the `Greedy` algorithm. 
+Select inducing points according to the algorithm `alg`. For some algorithms, additional keyword arguments are required. 
 """
 inducingpoints
 
@@ -76,9 +74,10 @@ end
 
 ## Online IP selection functions 
 @doc raw"""
-    updateZ!([rng::AbstractRNG], Z::AbstractVector, alg::OnIPSA, X::AbstractVector; kwargs...)
+    updateZ!([rng::AbstractRNG], Z::AbstractVector, alg::OnIPSA, X::AbstractVector; [kwargs...])
 
-Update inducing points `Z` with data `X` and algorithm `alg`
+Update inducing points `Z` with data `X` and algorithm `alg`. Requires additional keyword arguments
+for some algorithms. Also see `InducingPoints`.
 """
 updateZ!
 

--- a/src/InducingPoints.jl
+++ b/src/InducingPoints.jl
@@ -50,10 +50,12 @@ const OnIPSA = OnlineInducingPointsSelectionAlg
 
 ## Wrapper for matrices
 """
-     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractVector; kwargs...)
-     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractMatrix; obsdim=1, kwargs...)
+     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractVector; 
+        [y::AbstractVector, kernel::Kernel, noise::Real])
+     inducingpoints([rng::AbstractRNG], alg::OffIPSA, X::AbstractMatrix; 
+        obsdim=1, [y::AbstractVector, kernel::Kernel, noise::Real])
 
-Select inducing points according to the algorithm `alg`.
+Select inducing points according to the algorithm `alg`. The `kernel` keyword argument is required for the `Greedy`, `OnlineIPSelection`, `SeqDPP` algorithms. The `y` and `noise` keyword arguments are required for the `Greedy` algorithm. 
 """
 inducingpoints
 

--- a/src/offline/greedyip.jl
+++ b/src/offline/greedyip.jl
@@ -5,7 +5,7 @@
  - `s` is the minibatch size on which to select a new inducing point
 
 Greedy approach first proposed by Titsias[1].
-Algorithm loops over minibatches of data and select the best ELBO improvement.
+Algorithm loops over minibatches of data and select the best ELBO improvement. Requires passing outputs `y`, the `kernel` and the `noise` as keyword arguments to `inducingpoints`.
 
 [1] Titsias, M. Variational Learning of Inducing Variables in Sparse Gaussian Processes. Aistats 5, 567–574 (2009).
 """

--- a/src/offline/greedyip.jl
+++ b/src/offline/greedyip.jl
@@ -1,5 +1,5 @@
 """
-    GreedyIP(m::Int, s::Int)
+    Greedy(m::Int, s::Int)
 
  - `m` is the desired number of inducing points
  - `s` is the minibatch size on which to select a new inducing point

--- a/src/offline/greedyip.jl
+++ b/src/offline/greedyip.jl
@@ -67,7 +67,9 @@ function greedy_ip(
         )
         for j in d # Loop over every sample and evaluate the elbo addition with each new sample
             ℐᵢₚ₊ = union(ℐᵢₚ, j)
-            L = AbstractGPs.elbo(f(X[collect(ℐₜₑₛₜ)], noise), y[collect(ℐₜₑₛₜ)], f(X[collect(ℐᵢₚ₊)]))
+            L = AbstractGPs.elbo(
+                f(X[collect(ℐₜₑₛₜ)], noise), y[collect(ℐₜₑₛₜ)], f(X[collect(ℐᵢₚ₊)])
+            )
             if L > best_L
                 best_i = j
                 best_L = L

--- a/src/offline/greedyip.jl
+++ b/src/offline/greedyip.jl
@@ -19,6 +19,14 @@ struct Greedy <: OffIPSA
     end
 end
 
+"""
+     inducingpoints([rng::AbstractRNG], alg::Greedy, X::AbstractVector; 
+        y::AbstractVector, kernel::Kernel, noise::Real)
+     inducingpoints([rng::AbstractRNG], alg::Greedy, X::AbstractMatrix; 
+        obsdim=1, y::AbstractVector, kernel::Kernel, noise::Real)
+
+Select inducing points according using the Greedy algorithm. Requires as additional keyword arguments the outputs `y`, the `kernel` and the `noise`.
+"""
 function inducingpoints(
     rng::AbstractRNG,
     alg::Greedy,

--- a/src/offline/kmeans.jl
+++ b/src/offline/kmeans.jl
@@ -64,7 +64,7 @@ function kmeans_ip(
     end
 end
 
-"""Fast and efficient seeding for KMeans based on [`Fast and Provably Good Seeding for k-Means](https://las.inf.ethz.ch/files/bachem16fast.pdf)"""
+"""Fast and efficient seeding for KMeans based on [Fast and Provably Good Seeding for k-Means](https://las.inf.ethz.ch/files/bachem16fast.pdf)"""
 function kmeans_seeding(
     rng::AbstractRNG,
     X::AbstractVector, # Input data

--- a/src/online/oips.jl
+++ b/src/online/oips.jl
@@ -3,7 +3,10 @@
     OIPS(kmax, η=0.98, kmin=10)
 
 Online Inducing Points Selection.
-Method from the paper include reference here.
+Method from [1]. Requires passing the `kernel` as keyword argument to `inducingpoints`.
+
+[1] Galy-Fajou, T. & Opper, M Adaptive Inducing Points Selection for Gaussian Processes. arXiv:2107.10066v1 (2021).
+
 """
 struct OnlineIPSelection{T,Tv<:AbstractVector{T},Tk} <: OnIPSA
     ρs::Tv # Vector of two elements corresponding to ρ_accept and ρ_remove

--- a/src/online/oips.jl
+++ b/src/online/oips.jl
@@ -42,6 +42,12 @@ function OIPS(kmax::Int, η::T=0.98, kmin::Real=10) where {T<:Real}
     return OIPS(T[0.95, sqrt(0.95)], kmax, kmin, η)
 end
 
+"""
+     inducingpoints([rng::AbstractRNG], alg::OIPS, X::AbstractVector; kernel::Kernel)
+     inducingpoints([rng::AbstractRNG], alg::OIPS, X::AbstractMatrix; obsdim=1, kernel::Kernel)
+
+Select inducing points according using the Greedy algorithm. Requires as additional keyword argument the `kernel`.
+"""
 function inducingpoints(
     rng::AbstractRNG,
     alg::OIPS,
@@ -70,6 +76,12 @@ function updateZ!(
     return add_point!(rng, Z, alg, X, kernel)
 end
 
+@doc raw"""
+    updateZ!([rng::AbstractRNG], Z::AbstractVector, alg::OIPS, X::AbstractVector; kernel::Kernel)
+
+Update inducing points `Z` with data `X` and the OnlineIPSelection algorithm. Requires the `kernel` as an 
+additional keyword argument. 
+"""
 function updateZ(
     rng::AbstractRNG,
     Z::AbstractVector,

--- a/src/online/seqdpp.jl
+++ b/src/online/seqdpp.jl
@@ -1,7 +1,7 @@
 """
     SeqDPP()
 
-Sequential sampling via Determinantal Point Processes
+Sequential sampling via Determinantal Point Processes. Requires passing the `kernel` as keyword argument to `inducingpoints`.
 """
 struct SeqDPP <: OnIPSA end
 

--- a/src/online/seqdpp.jl
+++ b/src/online/seqdpp.jl
@@ -7,6 +7,12 @@ struct SeqDPP <: OnIPSA end
 
 Base.show(io::IO, ::SeqDPP) = print(io, "Sequential DPP")
 
+"""
+     inducingpoints([rng::AbstractRNG], alg::SeqDPP, X::AbstractVector; kernel::Kernel)
+     inducingpoints([rng::AbstractRNG], alg::SeqDPP, X::AbstractMatrix; obsdim=1, kernel::Kernel)
+
+Select inducing points according using Sequential Determinantal Point Processes. Requires as additional keyword argument the `kernel`.
+"""
 function inducingpoints(
     rng::AbstractRNG,
     ::SeqDPP,

--- a/src/online/streamkmeans.jl
+++ b/src/online/streamkmeans.jl
@@ -3,7 +3,7 @@
 
 Online clustering algorithm [1] to select inducing points in a streaming setting.
 Reference :
-[1] Liberty, E., Sriharsha, R. & Sviridenko, M. An Algorithm for Online K-Means Clustering. arXiv:1412.5721 [cs] (2015).
+[1] Liberty, E., Sriharsha, R. & Sviridenko, M. An Algorithm for Online K-Means Clustering. arXiv:1412.5721 (2015).
 """
 mutable struct StreamKmeans{T} <: OnIPSA
     m_target::Int

--- a/src/online/unigrid.jl
+++ b/src/online/unigrid.jl
@@ -40,7 +40,8 @@ function updateZ!(
 end
 
 function updateZ(
-    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs)
+    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector
+)
     Zn = deepcopy(Z)
-    updateZ!(rng, Zn, alg, X; kwargs...)
+    return updateZ!(rng, Zn, alg, X)
 end

--- a/src/online/unigrid.jl
+++ b/src/online/unigrid.jl
@@ -39,9 +39,7 @@ function updateZ!(
     return Z
 end
 
-function updateZ(
-    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector
-)
+function updateZ(rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector)
     Zn = deepcopy(Z)
     return updateZ!(rng, Zn, alg, X)
 end

--- a/src/online/unigrid.jl
+++ b/src/online/unigrid.jl
@@ -40,7 +40,7 @@ function updateZ!(
 end
 
 function updateZ(
-    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs...)
+    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs)
     Zn = deepcopy(Z)
-    updateZ!(rng, Zn, alg, X; kwargs)
+    updateZ!(rng, Zn, alg, X; kwargs...)
 end

--- a/src/online/unigrid.jl
+++ b/src/online/unigrid.jl
@@ -23,23 +23,28 @@ function inducingpoints(
     Z = map(bounds) do lims
         LinRange(lims..., alg.m)
     end
-    return Z
+    tmp = Iterators.product(Z...)
+    Zm = reshape(collect(Iterators.flatten(tmp)), ndim, :)
+    return ColVecs(Zm)
 end
 
 function updateZ!(
     ::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs...
 )
-    ndim = length(Z)
+    ndim = length(first(Z))
+    old_bounds = collect(zip(Z[1], Z[end]))
     new_bounds = [extrema(x -> getindex(x, i), X) for i in 1:ndim]
-    map!(Z, Z, new_bounds) do Z_d, new_b
-        x_start = min(Z_d.start, new_b[1]) # Find the new limits
-        x_stop = max(Z_d.stop, new_b[2])
+    newZ = map(old_bounds, new_bounds) do old_b, new_b
+        x_start = min(old_b[1], new_b[1]) # Find the new limits
+        x_stop = max(old_b[2], new_b[2])
         return LinRange(x_start, x_stop, alg.m) # readapt bounds
     end
+    tmp = Iterators.product(newZ...)
+    Z.X[:] = collect(Iterators.flatten(tmp))
     return Z
 end
 
-function updateZ(rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector)
+function updateZ(rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs...)
     Zn = deepcopy(Z)
-    return updateZ!(rng, Zn, alg, X)
+    return updateZ!(rng, Zn, alg, X; kwargs...)
 end

--- a/src/online/unigrid.jl
+++ b/src/online/unigrid.jl
@@ -38,3 +38,9 @@ function updateZ!(
     end
     return Z
 end
+
+function updateZ(
+    rng::AbstractRNG, Z::AbstractVector, alg::UniGrid, X::AbstractVector; kwargs...)
+    Zn = deepcopy(Z)
+    updateZ!(rng, Zn, alg, X; kwargs)
+end

--- a/test/online/unigrid.jl
+++ b/test/online/unigrid.jl
@@ -1,0 +1,10 @@
+@testset "UniGrid" begin
+    seed!(42)
+    N = 30
+    D = 3
+    nInd = 20
+    X = ColVecs(rand(D, N) * 10)
+    alg = UniGrid(nInd)
+    @test repr(alg) == "Uniform grid with side length $nInd."
+    test_Zalg(alg)
+end

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -15,27 +15,27 @@ function test_Zalg(alg::InducingPoints.OnIPSA, N::Int=30, D::Int=3; kwargs...)
         for T in [Float64, Float32]
             X = [rand(T, D) * 10 for _ in 1:N]
             Z = inducingpoints(alg, X; arraytype=Vector{T}, kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
             X2 = [rand(T, D) * 10 for _ in 1:N]
             Z = updateZ!(Z, alg, X2; kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
             Z = updateZ(Z, alg, X2; kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
         end
     end
     @testset "Test ColVecs" begin
         for T in [Float64, Float32]
             X = ColVecs(rand(T, D, N) * 10)
             Z = inducingpoints(alg, X; arraytype=Vector{T}, kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
             X2 = ColVecs(rand(T, D, 2 * N) * 10)
             X3 = [rand(T, D) * 10 for _ in 1:N]
             Z = updateZ!(Z, alg, X2; kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
             Z = updateZ!(Z, alg, X3; kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
             Z = updateZ(Z, alg, X2; kwargs...)
-            @test eltype(Z) == Vector{T}
+            @test eltype(Z) <: AbstractVector{T}
         end
     end
 end


### PR DESCRIPTION
This is my attempt to make UniGrid return something that looks like a `Vector`, while being as efficient as I can make it. 
I spent much time looking into "Lazy" implementations, but the best I could find was "Iterators.product", which returns `Tuple`s, which don't work with some of the `ApproximateGPs.jl` stuff that I played with. 

I had to change some `eltype(...) == Vector(...)` into `eltype(...) <: AbstractVector` to make the tests work with `ColVecs` output. 

This is not final just yet, as there is some more polish to do. Either in this PR or in another one, I think it would be good to streamline the output types. I personally like what can be seen in `KmeansAlg`, which returns a `Vector{<:Real}` for scalar inputs `x` and a `ColVecs` otherwise (i.e multidim inputs), and I think that perhaps all methods could do that.   

