### PR TITLE
Changing coverage tool to codecov.io

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,9 +46,8 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - name: Send coverage
+      - name: Send coverage to CodeCov
         if: matrix.version == '1' && matrix.os == 'ubuntu-latest'
-        uses: coverallsapp/github-action@master
+        uses: codecov/codecov-action@v2
         with:
-            github-token: ${{ secrets.GITHUB_TOKEN }}
-            path-to-lcov: ./lcov.info
+            file: lcov.info


### PR DESCRIPTION
The current coverage tool Coveralls does not show coverage by line, only "Source not available". 
While trying to understand what is going on, I saw https://github.com/JuliaGaussianProcesses/KernelFunctions.jl/pull/381 and therefore it seems sensible to me to also change the coverage tool here. 