### PR TITLE
Deprecate kernel field in StdDPP and kDPP

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InducingPoints"
 uuid = "b4bd816d-b975-4295-ac05-5f2992945579"
 authors = ["Théo Galy-Fajou <theo.galyfajou@gmail.com> and JuliaGaussianProcesses"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InducingPoints"
 uuid = "b4bd816d-b975-4295-ac05-5f2992945579"
 authors = ["Théo Galy-Fajou <theo.galyfajou@gmail.com> and JuliaGaussianProcesses"]
-version = "0.3.6"
+version = "0.4.0"
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -109,8 +109,8 @@ Sample from a k-Determinantal Point Process to select `k` points. `Z` will be a 
 
 ```@example base
 kernel = SqExponentialKernel()
-alg = kDPP(M, kernel)
-Z = inducingpoints(alg, x)
+alg = kDPP(M)
+Z = inducingpoints(alg, x; kernel)
 fig = plot_inducing_points(x, Z) # hide
 save("kdpp.svg", fig); nothing # hide
 ```
@@ -123,8 +123,8 @@ Samples from a standard Determinantal Point Process. The number of inducing poin
 
 ```@example base
 kernel = with_lengthscale(SqExponentialKernel(), 0.2)
-alg = StdDPP(kernel)
-Z = inducingpoints(alg, x)
+alg = StdDPP()
+Z = inducingpoints(alg, x; kernel)
 fig = plot_inducing_points(x, Z) # hide
 save("StdDPP.svg", fig); nothing # hide
 ```

--- a/src/offline/greedy_var_selection.jl
+++ b/src/offline/greedy_var_selection.jl
@@ -92,7 +92,7 @@ end
 See `GreedyVarSelection` for more info. `rng` isn't actually used here.
 """
 function inducingpoints(
-    rng::AbstractRNG, alg::GreedyVarSelection, x::AbstractVector; kernel::Kernel
+    ::AbstractRNG, alg::GreedyVarSelection, x::AbstractVector; kernel::Kernel
 )
     # Don't try to handle this case.
     alg.M > length(x) && throw(ArgumentError("M > length(x). Requires M <= length(x)."))

--- a/src/offline/greedyip.jl
+++ b/src/offline/greedyip.jl
@@ -89,15 +89,3 @@ function greedy_ip(
     end
     return X[collect(ℐᵢₚ)]
 end
-
-# function elbo(Z::AbstractVector, X::AbstractVector, y::AbstractVector, kernel::Kernel, σ²::Real)
-#     Knm = kernelmatrix(kernel, X, Z)
-#     Kmm = kernelmatrix(kernel, Z) + T(jitt) * I
-#     Qff = Knm * (Kmm \ Knm')
-#     Kt = kerneldiagmatrix(kernel, X) .+ T(jitt) - diag(Qff)
-#     Σ = inv(Kmm) + Knm' * Knm / σ²
-#     invQnn = 1/σ² * I - 1/ (σ²)^2 * Knm * inv(Σ) * Knm'
-#     logdetQnn = logdet(Σ) + logdet(Kmm)
-#     return -0.5 * dot(y, invQnn * y) - 0.5 * logdetQnn -
-#            1.0 / (2 * σ²) * sum(Kt)
-# end

--- a/src/offline/kdpp.jl
+++ b/src/offline/kdpp.jl
@@ -13,7 +13,9 @@ struct kDPP <: OffIPSA
     end
 end
 
-function inducingpoints(rng::AbstractRNG, alg::kDPP, X::AbstractVector; kernel::Kernel, kwargs...)
+function inducingpoints(
+    rng::AbstractRNG, alg::kDPP, X::AbstractVector; kernel::Kernel, kwargs...
+)
     if alg.m >= length(X)
         return edge_case(alg.m, length(X), X)
     end

--- a/src/offline/kdpp.jl
+++ b/src/offline/kdpp.jl
@@ -13,11 +13,17 @@ struct kDPP{K<:Kernel} <: OffIPSA
     end
 end
 
-function inducingpoints(rng::AbstractRNG, alg::kDPP, X::AbstractVector; kwargs...)
+function inducingpoints(rng::AbstractRNG, alg::kDPP, X::AbstractVector; kernel=nothing, kwargs...)
+    kernel = if isnothing(kernel)
+        @warn "The API for kDPP changes in the next breaking release. Please pass the kernel as a keyword argument."
+        alg.kernel
+    else
+        kernel
+    end
     if alg.m >= length(X)
         return edge_case(alg.m, length(X), X)
     end
-    return kdpp_ip(rng, X, alg.m, alg.kernel)
+    return kdpp_ip(rng, X, alg.m, kernel)
 end
 
 Base.show(io::IO, ::kDPP) = print(io, "k-DPP selection of inducing points")

--- a/src/offline/kdpp.jl
+++ b/src/offline/kdpp.jl
@@ -1,32 +1,26 @@
 """
-    kDPP(m::Int, kernel::Kernel)
+    kDPP(m::Int)
 
 k-DPP (Determinantal Point Process) will return a subset of `X` of size `m`,
-according to DPP probability
+according to DPP probability.
+The kernel is passed as a keyword argument to [`inducingpoints`](@ref).
 """
-struct kDPP{K<:Kernel} <: OffIPSA
+struct kDPP <: OffIPSA
     m::Int
-    kernel::K
-    function kDPP(m::Int, kernel::K) where {K<:Kernel}
+    function kDPP(m::Int)
         m > 0 || throw(ArgumentError("The number of inducing points m should be positive"))
-        return new{K}(m, kernel)
+        return new(m)
     end
 end
 
-function inducingpoints(rng::AbstractRNG, alg::kDPP, X::AbstractVector; kernel=nothing, kwargs...)
-    kernel = if isnothing(kernel)
-        @warn "The API for kDPP changes in the next breaking release. Please pass the kernel as a keyword argument."
-        alg.kernel
-    else
-        kernel
-    end
+function inducingpoints(rng::AbstractRNG, alg::kDPP, X::AbstractVector; kernel::Kernel, kwargs...)
     if alg.m >= length(X)
         return edge_case(alg.m, length(X), X)
     end
     return kdpp_ip(rng, X, alg.m, kernel)
 end
 
-Base.show(io::IO, ::kDPP) = print(io, "k-DPP selection of inducing points")
+Base.show(io::IO, alg::kDPP) = print(io, "k-DPP selection of $(alg.m) inducing points")
 
 function kdpp_ip(rng::AbstractRNG, X::AbstractVector, m::Int, kernel::Kernel)
     return X[rand(rng, DPP(kernel, X)(m))] # Sample m indices from a DPP

--- a/src/offline/stddpp.jl
+++ b/src/offline/stddpp.jl
@@ -7,7 +7,9 @@ The kernel is passed as a keyword argument to [`inducingpoints`](@ref).
 """
 struct StdDPP <: OffIPSA end
 
-function inducingpoints(rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kernel::Kernel, kwargs...)
+function inducingpoints(
+    rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kernel::Kernel, kwargs...
+)
     dpp = DPP(kernel, X)
     samp = rand(rng, dpp)
     while isempty(samp) # Sample from the DPP until there is a non-empty set

--- a/src/offline/stddpp.jl
+++ b/src/offline/stddpp.jl
@@ -1,20 +1,13 @@
 @doc raw"""
-    StdDPP(kernel::Kernel)
+    StdDPP()
 
-Standard DPP (Determinantal Point Process) sampling given `kernel`.
+Standard DPP (Determinantal Point Process) sampling.
 The size of the returned `Z` is not fixed (but is not allowed to be empty unlike in a classical DPP).
+The kernel is passed as a keyword argument to [`inducingpoints`](@ref).
 """
-struct StdDPP{K<:Kernel} <: OffIPSA
-    kernel::K
-end
+struct StdDPP <: OffIPSA end
 
-function inducingpoints(rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kernel=nothing, kwargs...)
-    kernel = if isnothing(kernel)
-        @warn "The API for StdDPP changes in the next breaking release. Please pass the kernel as a keyword argument."
-        alg.kernel
-    else
-        kernel
-    end
+function inducingpoints(rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kernel::Kernel, kwargs...)
     dpp = DPP(kernel, X)
     samp = rand(rng, dpp)
     while isempty(samp) # Sample from the DPP until there is a non-empty set

--- a/src/offline/stddpp.jl
+++ b/src/offline/stddpp.jl
@@ -6,13 +6,16 @@ The size of the returned `Z` is not fixed (but is not allowed to be empty unlike
 """
 struct StdDPP{K<:Kernel} <: OffIPSA
     kernel::K
-    function StdDPP(kernel::K) where {K<:Kernel}
-        return new{K}(kernel)
-    end
 end
 
-function inducingpoints(rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kwargs...)
-    dpp = DPP(alg.kernel, X)
+function inducingpoints(rng::AbstractRNG, alg::StdDPP, X::AbstractVector; kernel=nothing, kwargs...)
+    kernel = if isnothing(kernel)
+        @warn "The API for StdDPP changes in the next breaking release. Please pass the kernel as a keyword argument."
+        alg.kernel
+    else
+        kernel
+    end
+    dpp = DPP(kernel, X)
     samp = rand(rng, dpp)
     while isempty(samp) # Sample from the DPP until there is a non-empty set
         samp = rand(rng, dpp)

--- a/src/online/seqdpp.jl
+++ b/src/online/seqdpp.jl
@@ -1,7 +1,8 @@
 """
     SeqDPP()
 
-Sequential sampling via Determinantal Point Processes. Requires passing the `kernel` as keyword argument to `inducingpoints`.
+Sequential sampling via Determinantal Point Processes.
+Requires passing a `kernel::Kernel` as a keyword argument to [`inducingpoints`](@ref).
 """
 struct SeqDPP <: OnIPSA end
 
@@ -11,7 +12,8 @@ Base.show(io::IO, ::SeqDPP) = print(io, "Sequential DPP")
      inducingpoints([rng::AbstractRNG], alg::SeqDPP, X::AbstractVector; kernel::Kernel)
      inducingpoints([rng::AbstractRNG], alg::SeqDPP, X::AbstractMatrix; obsdim=1, kernel::Kernel)
 
-Select inducing points according using Sequential Determinantal Point Processes. Requires as additional keyword argument the `kernel`.
+Select inducing points according using Sequential Determinantal Point Processes.
+Requires passing a `kernel::Kernel` as a keyword argument.
 """
 function inducingpoints(
     rng::AbstractRNG,

--- a/test/offline/kdpp.jl
+++ b/test/offline/kdpp.jl
@@ -5,11 +5,11 @@
     nInd = 10
     kernel = SqExponentialKernel()
     X = ColVecs(rand(D, N))
-    alg = kDPP(nInd, kernel)
+    alg = kDPP(nInd)
     @test repr(alg) == "k-DPP selection of inducing points"
     Z = inducingpoints(alg, X; kernel)
     @test length(Z) == nInd
     @test_throws ArgumentError kDPP(-1, kernel)
-    @test_throws ErrorException inducingpoints(kDPP(100, kernel), X; kernel)
+    @test_throws ErrorException inducingpoints(kDPP(100), X; kernel)
     test_Zalg(kDPP(nInd, kernel), N)
 end

--- a/test/offline/kdpp.jl
+++ b/test/offline/kdpp.jl
@@ -6,10 +6,10 @@
     kernel = SqExponentialKernel()
     X = ColVecs(rand(D, N))
     alg = kDPP(nInd)
-    @test repr(alg) == "k-DPP selection of inducing points"
+    @test repr(alg) == "k-DPP selection of $(nInd) inducing points"
     Z = inducingpoints(alg, X; kernel)
     @test length(Z) == nInd
-    @test_throws ArgumentError kDPP(-1, kernel)
+    @test_throws ArgumentError kDPP(-1)
     @test_throws ErrorException inducingpoints(kDPP(100), X; kernel)
-    test_Zalg(kDPP(nInd, kernel), N)
+    test_Zalg(kDPP(nInd), N; kernel)
 end

--- a/test/offline/kdpp.jl
+++ b/test/offline/kdpp.jl
@@ -7,9 +7,9 @@
     X = ColVecs(rand(D, N))
     alg = kDPP(nInd, kernel)
     @test repr(alg) == "k-DPP selection of inducing points"
-    Z = inducingpoints(alg, X)
+    Z = inducingpoints(alg, X; kernel)
     @test length(Z) == nInd
     @test_throws ArgumentError kDPP(-1, kernel)
-    @test_throws ErrorException inducingpoints(kDPP(100, kernel), X)
+    @test_throws ErrorException inducingpoints(kDPP(100, kernel), X; kernel)
     test_Zalg(kDPP(nInd, kernel), N)
 end

--- a/test/offline/stddpp.jl
+++ b/test/offline/stddpp.jl
@@ -1,3 +1,3 @@
 @testset "stddpp.jl" begin
-    test_Zalg(StdDPP(SqExponentialKernel()))
+    test_Zalg(StdDPP(SqExponentialKernel()); kernel=SqExponentialKernel())
 end

--- a/test/offline/stddpp.jl
+++ b/test/offline/stddpp.jl
@@ -1,3 +1,3 @@
 @testset "stddpp.jl" begin
-    test_Zalg(StdDPP(SqExponentialKernel()); kernel=SqExponentialKernel())
+    test_Zalg(StdDPP(); kernel=SqExponentialKernel())
 end


### PR DESCRIPTION
Solves #39 by removing kernel as part of the field in the DPP structs and add them as kwargs instead.

Since the structs and API changes, this is considered a breaking release.